### PR TITLE
Server 데이터 관련 수정

### DIFF
--- a/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
+++ b/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
@@ -72,5 +72,5 @@ public class InstanceEntity {
 
 	@Builder.Default
 	@Column(name = "deleted", nullable = false)
-	private boolean deleted = false;
+	private Boolean deleted = false;
 }

--- a/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
+++ b/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
@@ -20,12 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 @Table(
 		name = "instances",
-		uniqueConstraints = {
-			@UniqueConstraint(name = "uq_instance_alias", columnNames = "alias"),
-			@UniqueConstraint(
-					name = "uq_source",
-					columnNames = {"source_type", "source_target_id"})
-		})
+		uniqueConstraints = {@UniqueConstraint(name = "uq_instance_alias", columnNames = "alias")})
 @EntityListeners(AuditingEntityListener.class)
 public class InstanceEntity {
 	@Id

--- a/src/main/java/com/okestro/resource/server/domain/vo/ImageSource.java
+++ b/src/main/java/com/okestro/resource/server/domain/vo/ImageSource.java
@@ -1,12 +1,13 @@
 package com.okestro.resource.server.domain.vo;
 
 import com.okestro.resource.server.domain.enums.SourceType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import lombok.NonNull;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.*;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Embeddable
 public class ImageSource {
 	@NonNull
@@ -17,4 +18,14 @@ public class ImageSource {
 	@NonNull
 	@Column(name = "source_target_id", nullable = false)
 	private Long sourceTargetId;
+
+	@Nullable @Transient private String sourceName;
+
+	public static ImageSource create(SourceType sourceType, Long sourceTargetId) {
+		return new ImageSource(sourceType, sourceTargetId, null);
+	}
+
+	public static ImageSource of(SourceType sourceType, Long sourceTargetId, String sourceName) {
+		return new ImageSource(sourceType, sourceTargetId, sourceName);
+	}
 }

--- a/src/main/resources/db/migration/entity/V1.00.0.5__instance_drop_uq_soruce.sql
+++ b/src/main/resources/db/migration/entity/V1.00.0.5__instance_drop_uq_soruce.sql
@@ -1,0 +1,1 @@
+alter table instances drop constraint  uq_source;


### PR DESCRIPTION
- 원시 타입으로 선언되어 있던 클래스 래핑 타입으로 수정
- ImageSource에 vo를 위한 멤버 추가 (sourceName)
- instance 테이블의 잘못된 제약 제거 uq_source: 하나의 소스로 하나의 인스턴스만 만들 수 있는 것이 아니기 때문