### PR TITLE
가상 서버 수정 API 구현

### DIFF
--- a/src/main/java/com/okestro/resource/config/WebMvcConfig.java
+++ b/src/main/java/com/okestro/resource/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.okestro.resource.config;
 
+import com.okestro.resource.server.controller.support.InstancePowerStatusActionConverter;
 import com.okestro.resource.support.web.converter.*;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 		registry.addConverter(new LocalDateParamBinder());
 		registry.addConverter(new LocalTimeParamBinder());
 		registry.addConverter(new LocalDateTimeParamBinder());
+		registry.addConverter(new InstancePowerStatusActionConverter());
 	}
 
 	@Override

--- a/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
+++ b/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
@@ -39,7 +39,7 @@ public class UpdateInstancePowerUseCase {
 			publishEvent(updatedPowerInstance);
 		}
 
-		return UpdateInstancePowerUsecaseDto.out(updatedPowerInstance, isUpdated);
+		return UpdateInstancePowerUsecaseDto.out(updatedPowerInstance);
 	}
 
 	private Instance findInstance(Long instanceId) {

--- a/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
+++ b/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
@@ -1,0 +1,57 @@
+package com.okestro.resource.server.application;
+
+import com.okestro.resource.server.application.dto.UpdateInstancePowerUsecaseDto;
+import com.okestro.resource.server.application.service.power.InstancePowerActionManager;
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import com.okestro.resource.server.event.ServerEventPublisher;
+import com.okestro.resource.server.event.instance.InstanceEvent;
+import com.okestro.resource.server.support.json.ServerAction;
+import com.okestro.resource.server.support.json.ServerActionJson;
+import com.okestro.resource.server.support.json.ServerJsonConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateInstancePowerUseCase {
+	private final ServerEventPublisher serverEventPublisher;
+	private final ServerJsonConverter serverJsonConverter;
+
+	private final InstanceRepository instanceRepository;
+	private final InstancePowerActionManager instancePowerActionManager;
+
+	@Transactional
+	public UpdateInstancePowerUsecaseDto.UpdateInstanceUseCaseOut execute(
+			UpdateInstancePowerUsecaseDto.UpdateInstancePowerUseCaseIn useCaseIn) {
+		final Long instanceId = useCaseIn.getInstanceId();
+		final InstancePowerStatusAction powerStatusAction = useCaseIn.getPowerStatusAction();
+
+		final Instance instance = findInstance(instanceId);
+		final Instance updatedPowerInstance =
+				instancePowerActionManager.execute(instance, powerStatusAction);
+
+		publishEvent(updatedPowerInstance);
+		return UpdateInstancePowerUsecaseDto.out(updatedPowerInstance);
+	}
+
+	private Instance findInstance(Long instanceId) {
+		return Instance.from(
+				instanceRepository
+						.findById(instanceId)
+						.orElseThrow(
+								() -> new IllegalArgumentException("Instance not found with id: " + instanceId)));
+	}
+
+	private void publishEvent(Instance savedInstance) {
+		ServerActionJson serverActionJson =
+				serverJsonConverter.toJson(ServerAction.UPDATE, savedInstance);
+		InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent.InstanceUpdateLogEvent
+				event =
+						new InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent
+								.InstanceUpdateLogEvent(savedInstance.getId(), serverActionJson);
+		serverEventPublisher.publishEvent(event);
+	}
+}

--- a/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
+++ b/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
@@ -4,6 +4,7 @@ import com.okestro.resource.server.application.dto.UpdateInstancePowerUsecaseDto
 import com.okestro.resource.server.application.service.power.InstancePowerActionManager;
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import com.okestro.resource.server.domain.repository.InstanceRepository;
 import com.okestro.resource.server.event.ServerEventPublisher;
 import com.okestro.resource.server.event.instance.InstanceEvent;
@@ -34,7 +35,9 @@ public class UpdateInstancePowerUseCase {
 				instancePowerActionManager.execute(instance, powerStatusAction);
 
 		publishEvent(updatedPowerInstance);
-		return UpdateInstancePowerUsecaseDto.out(updatedPowerInstance);
+
+		boolean isUpdated = instance instanceof UpdatedInstance;
+		return UpdateInstancePowerUsecaseDto.out(updatedPowerInstance, isUpdated);
 	}
 
 	private Instance findInstance(Long instanceId) {

--- a/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
+++ b/src/main/java/com/okestro/resource/server/application/UpdateInstancePowerUseCase.java
@@ -34,9 +34,11 @@ public class UpdateInstancePowerUseCase {
 		final Instance updatedPowerInstance =
 				instancePowerActionManager.execute(instance, powerStatusAction);
 
-		publishEvent(updatedPowerInstance);
+		boolean isUpdated = updatedPowerInstance instanceof UpdatedInstance;
+		if (isUpdated) {
+			publishEvent(updatedPowerInstance);
+		}
 
-		boolean isUpdated = instance instanceof UpdatedInstance;
 		return UpdateInstancePowerUsecaseDto.out(updatedPowerInstance, isUpdated);
 	}
 

--- a/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
+++ b/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
@@ -1,0 +1,60 @@
+package com.okestro.resource.server.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.controller.request.UpdateInstancePowerRequest;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UpdateInstancePowerUsecaseDto {
+	public static UpdateInstancePowerUseCaseIn in(UpdateInstancePowerRequest request) {
+		return UpdateInstancePowerUseCaseIn.builder()
+				.instanceId(request.getInstanceId())
+				.powerStatusAction(request.getPowerStatusAction())
+				.build();
+	}
+
+	public static UpdateInstanceUseCaseOut out(Instance instance) {
+		boolean isUpdated = instance instanceof UpdatedInstance;
+		return UpdateInstanceUseCaseOut.builder()
+				.id(instance.getId())
+				.name(instance.getName())
+				.description(instance.getDescription())
+				.alias(instance.getAlias().getValue())
+				.powerStatus(instance.getPowerStatus().name())
+				.host(instance.getHost().getValue())
+				.updatedAt(instance.getUpdatedAt())
+				.isUpdated(isUpdated)
+				.build();
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder(toBuilder = true)
+	public static class UpdateInstancePowerUseCaseIn {
+		@NotNull private Long instanceId;
+		@NotNull private InstancePowerStatusAction powerStatusAction;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Builder(toBuilder = true)
+	public static class UpdateInstanceUseCaseOut {
+		@NotNull private Long id;
+		@NotNull private String name;
+		@NotNull private String description;
+		@NotNull private String alias;
+		@NotNull private String powerStatus;
+		@NotNull private String host;
+		@NotNull private LocalDateTime updatedAt;
+		@JsonIgnore @NotNull private Boolean isUpdated;
+	}
+}

--- a/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
+++ b/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
@@ -3,7 +3,6 @@ package com.okestro.resource.server.application.dto;
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.controller.request.UpdateInstancePowerRequest;
 import com.okestro.resource.server.domain.model.instance.Instance;
-import java.time.LocalDateTime;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +25,6 @@ public class UpdateInstancePowerUsecaseDto {
 				.alias(instance.getAlias().getValue())
 				.powerStatus(instance.getPowerStatus().name())
 				.host(instance.getHost().getValue())
-				.updatedAt(instance.getUpdatedAt())
 				.build();
 	}
 
@@ -50,6 +48,5 @@ public class UpdateInstancePowerUsecaseDto {
 		@NotNull private String alias;
 		@NotNull private String powerStatus;
 		@NotNull private String host;
-		@NotNull private LocalDateTime updatedAt;
 	}
 }

--- a/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
+++ b/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.controller.request.UpdateInstancePowerRequest;
 import com.okestro.resource.server.domain.model.instance.Instance;
-import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import java.time.LocalDateTime;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -20,8 +19,7 @@ public class UpdateInstancePowerUsecaseDto {
 				.build();
 	}
 
-	public static UpdateInstanceUseCaseOut out(Instance instance) {
-		boolean isUpdated = instance instanceof UpdatedInstance;
+	public static UpdateInstanceUseCaseOut out(Instance instance, boolean isUpdated) {
 		return UpdateInstanceUseCaseOut.builder()
 				.id(instance.getId())
 				.name(instance.getName())

--- a/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
+++ b/src/main/java/com/okestro/resource/server/application/dto/UpdateInstancePowerUsecaseDto.java
@@ -1,6 +1,5 @@
 package com.okestro.resource.server.application.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.controller.request.UpdateInstancePowerRequest;
 import com.okestro.resource.server.domain.model.instance.Instance;
@@ -19,7 +18,7 @@ public class UpdateInstancePowerUsecaseDto {
 				.build();
 	}
 
-	public static UpdateInstanceUseCaseOut out(Instance instance, boolean isUpdated) {
+	public static UpdateInstanceUseCaseOut out(Instance instance) {
 		return UpdateInstanceUseCaseOut.builder()
 				.id(instance.getId())
 				.name(instance.getName())
@@ -28,7 +27,6 @@ public class UpdateInstancePowerUsecaseDto {
 				.powerStatus(instance.getPowerStatus().name())
 				.host(instance.getHost().getValue())
 				.updatedAt(instance.getUpdatedAt())
-				.isUpdated(isUpdated)
 				.build();
 	}
 
@@ -53,6 +51,5 @@ public class UpdateInstancePowerUsecaseDto {
 		@NotNull private String powerStatus;
 		@NotNull private String host;
 		@NotNull private LocalDateTime updatedAt;
-		@JsonIgnore @NotNull private Boolean isUpdated;
 	}
 }

--- a/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionManager.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionManager.java
@@ -1,0 +1,47 @@
+package com.okestro.resource.server.application.service.power;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class InstancePowerActionManager {
+	private final Map<InstancePowerStatusAction, InstancePowerActionService> instancePowerActions;
+
+	public InstancePowerActionManager(List<InstancePowerActionService> services) {
+		this.instancePowerActions =
+				services.stream()
+						.collect(
+								Collectors.toMap(
+										InstancePowerActionService::supportAction,
+										Function.identity(),
+										(existing, duplicate) -> {
+											throw new IllegalStateException(
+													"Duplicate key for supportAction: " + existing.supportAction());
+										}));
+
+		log.info(
+				"InstancePowerActionManager initialized with actions: {}", instancePowerActions.keySet());
+	}
+
+	public Instance execute(Instance instance, InstancePowerStatusAction action) {
+		PowerStatus wantPowerStatus = action.wantPowerStatus();
+		InstancePowerActionService instancePowerActionService =
+				Optional.ofNullable(instancePowerActions.getOrDefault(action, null))
+						.orElseThrow(() -> new IllegalArgumentException("Unsupported action: " + action));
+		log.debug(
+				"{} execute: {} for instance: {}",
+				instancePowerActionService.getClass().getSimpleName(),
+				action,
+				instance.getId());
+		return instancePowerActionService.doExecute(instance, wantPowerStatus);
+	}
+}

--- a/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionManager.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionManager.java
@@ -33,7 +33,7 @@ public class InstancePowerActionManager {
 	}
 
 	public Instance execute(Instance instance, InstancePowerStatusAction action) {
-		PowerStatus wantPowerStatus = action.expectedPowerStatus();
+		PowerStatus wantPowerStatus = InstancePowerStatusActionSupporter.getPowerStatus(action);
 		InstancePowerActionService instancePowerActionService =
 				Optional.ofNullable(instancePowerActions.getOrDefault(action, null))
 						.orElseThrow(() -> new IllegalArgumentException("Unsupported action: " + action));

--- a/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionManager.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionManager.java
@@ -33,7 +33,7 @@ public class InstancePowerActionManager {
 	}
 
 	public Instance execute(Instance instance, InstancePowerStatusAction action) {
-		PowerStatus wantPowerStatus = action.wantPowerStatus();
+		PowerStatus wantPowerStatus = action.expectedPowerStatus();
 		InstancePowerActionService instancePowerActionService =
 				Optional.ofNullable(instancePowerActions.getOrDefault(action, null))
 						.orElseThrow(() -> new IllegalArgumentException("Unsupported action: " + action));

--- a/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionService.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerActionService.java
@@ -1,0 +1,32 @@
+package com.okestro.resource.server.application.service.power;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class InstancePowerActionService {
+	public abstract InstancePowerStatusAction supportAction();
+
+	Instance doExecute(Instance originInstance, PowerStatus wantPowerStatus) {
+		Long instanceId = originInstance.getId();
+		PowerStatus currentPowerStatus = getCurrentPowerStatus(instanceId);
+		if (!isNeedToUpdate(currentPowerStatus, wantPowerStatus)) {
+			log.debug(
+					"Instance {} is already in the desired power status: {}", instanceId, wantPowerStatus);
+			return originInstance;
+		}
+
+		return updateInstance(instanceId, wantPowerStatus);
+	}
+
+	protected abstract PowerStatus getCurrentPowerStatus(Long instanceId);
+
+	protected boolean isNeedToUpdate(PowerStatus currentPowerStatus, PowerStatus wantPowerStatus) {
+		return currentPowerStatus != wantPowerStatus;
+	}
+
+	protected abstract UpdatedInstance updateInstance(Long instanceId, PowerStatus powerStatus);
+}

--- a/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerStatusActionSupporter.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/InstancePowerStatusActionSupporter.java
@@ -1,0 +1,29 @@
+package com.okestro.resource.server.application.service.power;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class InstancePowerStatusActionSupporter {
+	public static PowerStatus getPowerStatus(InstancePowerStatusAction action) {
+		if (action == null) {
+			throw new IllegalArgumentException("Action cannot be null");
+		}
+
+		if (action == InstancePowerStatusAction.START) {
+			return PowerStatus.RUNNING;
+		}
+		if (action == InstancePowerStatusAction.SHUTDOWN) {
+			return PowerStatus.SHUTDOWN;
+		}
+		if (action == InstancePowerStatusAction.REBOOT) {
+			return PowerStatus.RUNNING;
+		}
+		if (action == InstancePowerStatusAction.PAUSE) {
+			return PowerStatus.PAUSED;
+		}
+
+		throw new IllegalArgumentException("Unsupported action: " + action);
+	}
+}

--- a/src/main/java/com/okestro/resource/server/application/service/power/PauseInstancePowerActionService.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/PauseInstancePowerActionService.java
@@ -1,0 +1,43 @@
+package com.okestro.resource.server.application.service.power;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PauseInstancePowerActionService extends InstancePowerActionService {
+	private final InstanceRepository instanceRepository;
+
+	@Override
+	protected PowerStatus getCurrentPowerStatus(Long instanceId) {
+		return instanceRepository
+				.findById(instanceId)
+				.orElseThrow(
+						() -> new IllegalArgumentException("Instance not found with id: " + instanceId))
+				.getPowerStatus();
+	}
+
+	@Override
+	protected UpdatedInstance updateInstance(Long instanceId, PowerStatus powerStatus) {
+		Instance instance =
+				Instance.from(
+						instanceRepository
+								.findById(instanceId)
+								.orElseThrow(
+										() ->
+												new IllegalArgumentException("Instance not found with id: " + instanceId)));
+		UpdatedInstance pausedInstance = instance.pause();
+		return UpdatedInstance.from(instanceRepository.save(InstanceEntity.updateTo(pausedInstance)));
+	}
+
+	@Override
+	public InstancePowerStatusAction supportAction() {
+		return InstancePowerStatusAction.PAUSE;
+	}
+}

--- a/src/main/java/com/okestro/resource/server/application/service/power/RebootInstancePowerActionService.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/RebootInstancePowerActionService.java
@@ -1,0 +1,46 @@
+package com.okestro.resource.server.application.service.power;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RebootInstancePowerActionService extends InstancePowerActionService {
+	private final InstanceRepository instanceRepository;
+
+	@Override
+	protected PowerStatus getCurrentPowerStatus(Long instanceId) {
+		return instanceRepository
+				.findById(instanceId)
+				.orElseThrow(
+						() -> new IllegalArgumentException("Instance not found with id: " + instanceId))
+				.getPowerStatus();
+	}
+
+	@Override
+	protected UpdatedInstance updateInstance(Long instanceId, PowerStatus powerStatus) {
+		Instance instance =
+				Instance.from(
+						instanceRepository
+								.findById(instanceId)
+								.orElseThrow(
+										() ->
+												new IllegalArgumentException("Instance not found with id: " + instanceId)));
+		UpdatedInstance shutdownInstance =
+				UpdatedInstance.from(instanceRepository.save(InstanceEntity.updateTo(instance.shutdown())));
+		// TODO: do something for reboot
+		UpdatedInstance startedInstance = shutdownInstance.start();
+		return UpdatedInstance.from(instanceRepository.save(InstanceEntity.updateTo(startedInstance)));
+	}
+
+	@Override
+	public InstancePowerStatusAction supportAction() {
+		return InstancePowerStatusAction.REBOOT;
+	}
+}

--- a/src/main/java/com/okestro/resource/server/application/service/power/ShutdownInstancePowerActionService.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/ShutdownInstancePowerActionService.java
@@ -1,0 +1,43 @@
+package com.okestro.resource.server.application.service.power;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ShutdownInstancePowerActionService extends InstancePowerActionService {
+	private final InstanceRepository instanceRepository;
+
+	@Override
+	protected PowerStatus getCurrentPowerStatus(Long instanceId) {
+		return instanceRepository
+				.findById(instanceId)
+				.orElseThrow(
+						() -> new IllegalArgumentException("Instance not found with id: " + instanceId))
+				.getPowerStatus();
+	}
+
+	@Override
+	protected UpdatedInstance updateInstance(Long instanceId, PowerStatus powerStatus) {
+		Instance instance =
+				Instance.from(
+						instanceRepository
+								.findById(instanceId)
+								.orElseThrow(
+										() ->
+												new IllegalArgumentException("Instance not found with id: " + instanceId)));
+		UpdatedInstance shutdownInstance = instance.shutdown();
+		return UpdatedInstance.from(instanceRepository.save(InstanceEntity.updateTo(shutdownInstance)));
+	}
+
+	@Override
+	public InstancePowerStatusAction supportAction() {
+		return InstancePowerStatusAction.SHUTDOWN;
+	}
+}

--- a/src/main/java/com/okestro/resource/server/application/service/power/StartInstancePowerActionService.java
+++ b/src/main/java/com/okestro/resource/server/application/service/power/StartInstancePowerActionService.java
@@ -1,0 +1,43 @@
+package com.okestro.resource.server.application.service.power;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StartInstancePowerActionService extends InstancePowerActionService {
+	private final InstanceRepository instanceRepository;
+
+	@Override
+	protected PowerStatus getCurrentPowerStatus(Long instanceId) {
+		return instanceRepository
+				.findById(instanceId)
+				.orElseThrow(
+						() -> new IllegalArgumentException("Instance not found with id: " + instanceId))
+				.getPowerStatus();
+	}
+
+	@Override
+	protected UpdatedInstance updateInstance(Long instanceId, PowerStatus powerStatus) {
+		Instance instance =
+				Instance.from(
+						instanceRepository
+								.findById(instanceId)
+								.orElseThrow(
+										() ->
+												new IllegalArgumentException("Instance not found with id: " + instanceId)));
+		UpdatedInstance startedInstance = instance.start();
+		return UpdatedInstance.from(instanceRepository.save(InstanceEntity.updateTo(startedInstance)));
+	}
+
+	@Override
+	public InstancePowerStatusAction supportAction() {
+		return InstancePowerStatusAction.START;
+	}
+}

--- a/src/main/java/com/okestro/resource/server/controller/ServerController.java
+++ b/src/main/java/com/okestro/resource/server/controller/ServerController.java
@@ -1,10 +1,29 @@
 package com.okestro.resource.server.controller;
 
+import com.okestro.resource.server.application.UpdateInstancePowerUseCase;
+import com.okestro.resource.server.application.dto.UpdateInstancePowerUsecaseDto;
+import com.okestro.resource.server.controller.request.UpdateInstancePowerRequest;
+import com.okestro.resource.support.web.ApiResponse;
+import com.okestro.resource.support.web.ApiResponseGenerator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/v1/servers")
 @RequiredArgsConstructor
 @RestController
-public class ServerController {}
+public class ServerController {
+	private final UpdateInstancePowerUseCase updateInstancePowerUseCase;
+
+	@PutMapping("/instance/power")
+	public ApiResponse<
+					ApiResponse.SuccessBody<UpdateInstancePowerUsecaseDto.UpdateInstanceUseCaseOut>>
+			updateInstancePower(@RequestBody UpdateInstancePowerRequest request) {
+		UpdateInstancePowerUsecaseDto.UpdateInstanceUseCaseOut useCaseOut =
+				updateInstancePowerUseCase.execute(UpdateInstancePowerUsecaseDto.in(request));
+		if (useCaseOut.getIsUpdated()) {
+			return ApiResponseGenerator.success(useCaseOut, HttpStatus.OK);
+		}
+		return ApiResponseGenerator.success(useCaseOut, HttpStatus.NOT_MODIFIED);
+	}
+}

--- a/src/main/java/com/okestro/resource/server/controller/ServerController.java
+++ b/src/main/java/com/okestro/resource/server/controller/ServerController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class ServerController {
 	private final UpdateInstancePowerUseCase updateInstancePowerUseCase;
 
-	@PutMapping("/instance/power")
+	@PutMapping("/instances/power")
 	public ApiResponse<
 					ApiResponse.SuccessBody<UpdateInstancePowerUsecaseDto.UpdateInstanceUseCaseOut>>
 			updateInstancePower(@RequestBody UpdateInstancePowerRequest request) {

--- a/src/main/java/com/okestro/resource/server/controller/ServerController.java
+++ b/src/main/java/com/okestro/resource/server/controller/ServerController.java
@@ -21,9 +21,6 @@ public class ServerController {
 			updateInstancePower(@RequestBody UpdateInstancePowerRequest request) {
 		UpdateInstancePowerUsecaseDto.UpdateInstanceUseCaseOut useCaseOut =
 				updateInstancePowerUseCase.execute(UpdateInstancePowerUsecaseDto.in(request));
-		if (useCaseOut.getIsUpdated()) {
-			return ApiResponseGenerator.success(useCaseOut, HttpStatus.OK);
-		}
-		return ApiResponseGenerator.success(useCaseOut, HttpStatus.NOT_MODIFIED);
+		return ApiResponseGenerator.success(useCaseOut, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/okestro/resource/server/controller/request/InstancePowerStatusAction.java
+++ b/src/main/java/com/okestro/resource/server/controller/request/InstancePowerStatusAction.java
@@ -1,0 +1,49 @@
+package com.okestro.resource.server.controller.request;
+
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import lombok.Getter;
+
+@Getter
+public enum InstancePowerStatusAction {
+	START(0L) {
+		@Override
+		public PowerStatus wantPowerStatus() {
+			return PowerStatus.RUNNING;
+		}
+	},
+	SHUTDOWN(1L) {
+		@Override
+		public PowerStatus wantPowerStatus() {
+			return PowerStatus.SHUTDOWN;
+		}
+	},
+	REBOOT(2L) {
+		@Override
+		public PowerStatus wantPowerStatus() {
+			return PowerStatus.RUNNING;
+		}
+	},
+	PAUSE(3L) {
+		@Override
+		public PowerStatus wantPowerStatus() {
+			return PowerStatus.PAUSED;
+		}
+	};
+
+	private final Long actionCode;
+
+	InstancePowerStatusAction(Long actionCode) {
+		this.actionCode = actionCode;
+	}
+
+	public static InstancePowerStatusAction fromCode(Long code) {
+		for (InstancePowerStatusAction action : values()) {
+			if (action.getActionCode().equals(code)) {
+				return action;
+			}
+		}
+		throw new IllegalArgumentException("Invalid power status code: " + code);
+	}
+
+	public abstract PowerStatus wantPowerStatus();
+}

--- a/src/main/java/com/okestro/resource/server/controller/request/InstancePowerStatusAction.java
+++ b/src/main/java/com/okestro/resource/server/controller/request/InstancePowerStatusAction.java
@@ -1,34 +1,13 @@
 package com.okestro.resource.server.controller.request;
 
-import com.okestro.resource.server.domain.enums.PowerStatus;
 import lombok.Getter;
 
 @Getter
 public enum InstancePowerStatusAction {
-	START(0L) {
-		@Override
-		public PowerStatus expectedPowerStatus() {
-			return PowerStatus.RUNNING;
-		}
-	},
-	SHUTDOWN(1L) {
-		@Override
-		public PowerStatus expectedPowerStatus() {
-			return PowerStatus.SHUTDOWN;
-		}
-	},
-	REBOOT(2L) {
-		@Override
-		public PowerStatus expectedPowerStatus() {
-			return PowerStatus.RUNNING;
-		}
-	},
-	PAUSE(3L) {
-		@Override
-		public PowerStatus expectedPowerStatus() {
-			return PowerStatus.PAUSED;
-		}
-	};
+	START(0L),
+	SHUTDOWN(1L),
+	REBOOT(2L),
+	PAUSE(3L);
 
 	private final Long actionCode;
 
@@ -44,6 +23,4 @@ public enum InstancePowerStatusAction {
 		}
 		throw new IllegalArgumentException("Invalid power status code: " + code);
 	}
-
-	public abstract PowerStatus expectedPowerStatus();
 }

--- a/src/main/java/com/okestro/resource/server/controller/request/InstancePowerStatusAction.java
+++ b/src/main/java/com/okestro/resource/server/controller/request/InstancePowerStatusAction.java
@@ -7,25 +7,25 @@ import lombok.Getter;
 public enum InstancePowerStatusAction {
 	START(0L) {
 		@Override
-		public PowerStatus wantPowerStatus() {
+		public PowerStatus expectedPowerStatus() {
 			return PowerStatus.RUNNING;
 		}
 	},
 	SHUTDOWN(1L) {
 		@Override
-		public PowerStatus wantPowerStatus() {
+		public PowerStatus expectedPowerStatus() {
 			return PowerStatus.SHUTDOWN;
 		}
 	},
 	REBOOT(2L) {
 		@Override
-		public PowerStatus wantPowerStatus() {
+		public PowerStatus expectedPowerStatus() {
 			return PowerStatus.RUNNING;
 		}
 	},
 	PAUSE(3L) {
 		@Override
-		public PowerStatus wantPowerStatus() {
+		public PowerStatus expectedPowerStatus() {
 			return PowerStatus.PAUSED;
 		}
 	};
@@ -45,5 +45,5 @@ public enum InstancePowerStatusAction {
 		throw new IllegalArgumentException("Invalid power status code: " + code);
 	}
 
-	public abstract PowerStatus wantPowerStatus();
+	public abstract PowerStatus expectedPowerStatus();
 }

--- a/src/main/java/com/okestro/resource/server/controller/request/UpdateInstancePowerRequest.java
+++ b/src/main/java/com/okestro/resource/server/controller/request/UpdateInstancePowerRequest.java
@@ -1,0 +1,25 @@
+package com.okestro.resource.server.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder(toBuilder = true)
+public class UpdateInstancePowerRequest {
+	@Schema(description = "Instance id", example = "1")
+	@NotNull
+	private Long instanceId;
+
+	@Schema(
+			description = "Power status",
+			example = "1",
+			allowableValues = {"0", "1", "2", "3"})
+	@NotNull
+	private InstancePowerStatusAction powerStatusAction;
+}

--- a/src/main/java/com/okestro/resource/server/controller/support/InstancePowerStatusActionConverter.java
+++ b/src/main/java/com/okestro/resource/server/controller/support/InstancePowerStatusActionConverter.java
@@ -1,0 +1,12 @@
+package com.okestro.resource.server.controller.support;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import org.springframework.core.convert.converter.Converter;
+
+public class InstancePowerStatusActionConverter
+		implements Converter<Long, InstancePowerStatusAction> {
+	@Override
+	public InstancePowerStatusAction convert(Long source) {
+		return InstancePowerStatusAction.fromCode(source);
+	}
+}

--- a/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
+++ b/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
@@ -1,6 +1,7 @@
 package com.okestro.resource.server.domain;
 
 import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import com.okestro.resource.server.domain.support.InstanceAliasConverter;
 import com.okestro.resource.server.domain.support.InstanceHostConverter;
 import com.okestro.resource.server.domain.vo.ImageSource;
@@ -60,17 +61,32 @@ public class InstanceEntity {
 
 	@NonNull @Embedded private ImageSource imageSource;
 
-	@Column(name = "created_at", nullable = false, updatable = false)
+	@Column(name = "created_at", nullable = false)
 	@CreatedDate
 	private LocalDateTime createdAt;
 
-	@Column(name = "updated_at", nullable = false, updatable = false)
+	@Column(name = "updated_at", nullable = false)
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
 
 	@Builder.Default
 	@Column(name = "deleted", nullable = false)
 	private Boolean deleted = false;
+
+	public static InstanceEntity updateTo(UpdatedInstance instance) {
+		return InstanceEntity.builder()
+				.id(instance.getId())
+				.name(instance.getName())
+				.description(instance.getDescription())
+				.alias(instance.getAlias())
+				.powerStatus(instance.getPowerStatus())
+				.host(instance.getHost())
+				.flavorId(instance.getFlavorId())
+				.imageSource(instance.getImageSource())
+				.createdAt(instance.getCreatedAt())
+				.updatedAt(instance.getUpdatedAt())
+				.build();
+	}
 
 	@Override
 	public final boolean equals(Object o) {

--- a/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
+++ b/src/main/java/com/okestro/resource/server/domain/InstanceEntity.java
@@ -83,8 +83,6 @@ public class InstanceEntity {
 				.host(instance.getHost())
 				.flavorId(instance.getFlavorId())
 				.imageSource(instance.getImageSource())
-				.createdAt(instance.getCreatedAt())
-				.updatedAt(instance.getUpdatedAt())
 				.build();
 	}
 

--- a/src/main/java/com/okestro/resource/server/domain/model/instance/Instance.java
+++ b/src/main/java/com/okestro/resource/server/domain/model/instance/Instance.java
@@ -35,4 +35,20 @@ public class Instance extends BaseInstance {
 				instanceEntity.getFlavorId(),
 				instanceEntity.getId());
 	}
+
+	public UpdatedInstance start() {
+		return updatePowerStatus(PowerStatus.RUNNING);
+	}
+
+	public UpdatedInstance shutdown() {
+		return updatePowerStatus(PowerStatus.SHUTDOWN);
+	}
+
+	public UpdatedInstance pause() {
+		return updatePowerStatus(PowerStatus.PAUSED);
+	}
+
+	private UpdatedInstance updatePowerStatus(PowerStatus powerStatus) {
+		return UpdatedInstance.of(this, powerStatus);
+	}
 }

--- a/src/main/java/com/okestro/resource/server/domain/model/instance/UpdatedInstance.java
+++ b/src/main/java/com/okestro/resource/server/domain/model/instance/UpdatedInstance.java
@@ -1,0 +1,52 @@
+package com.okestro.resource.server.domain.model.instance;
+
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class UpdatedInstance extends Instance {
+	public UpdatedInstance(
+			String name,
+			String description,
+			InstanceAlias alias,
+			PowerStatus powerStatus,
+			InstanceHost host,
+			ImageSource imageSource,
+			Long flavorId,
+			Long id,
+			LocalDateTime createdAt) {
+		// updatedAt is set to null because it is set by the repository layer
+		super(name, description, alias, powerStatus, host, imageSource, flavorId, id, createdAt, null);
+	}
+
+	public static UpdatedInstance of(Instance instance, PowerStatus powerStatus) {
+		return new UpdatedInstance(
+				instance.getName(),
+				instance.getDescription(),
+				instance.getAlias(),
+				powerStatus,
+				instance.getHost(),
+				instance.getImageSource(),
+				instance.getFlavorId(),
+				instance.getId(),
+				instance.getCreatedAt());
+	}
+
+	public static UpdatedInstance from(InstanceEntity entity) {
+		return new UpdatedInstance(
+				entity.getName(),
+				entity.getDescription(),
+				entity.getAlias(),
+				entity.getPowerStatus(),
+				entity.getHost(),
+				entity.getImageSource(),
+				entity.getFlavorId(),
+				entity.getId(),
+				entity.getCreatedAt());
+	}
+}

--- a/src/main/java/com/okestro/resource/server/domain/model/instance/UpdatedInstance.java
+++ b/src/main/java/com/okestro/resource/server/domain/model/instance/UpdatedInstance.java
@@ -7,9 +7,26 @@ import com.okestro.resource.server.domain.vo.InstanceAlias;
 import com.okestro.resource.server.domain.vo.InstanceHost;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 @Getter
 public class UpdatedInstance extends Instance {
+	@Nullable private LocalDateTime createdAt;
+	@Nullable private LocalDateTime updatedAt;
+
+	public UpdatedInstance(
+			String name,
+			String description,
+			InstanceAlias alias,
+			PowerStatus powerStatus,
+			InstanceHost host,
+			ImageSource imageSource,
+			Long flavorId,
+			Long id) {
+		super(name, description, alias, powerStatus, host, imageSource, flavorId, id);
+	}
+
 	public UpdatedInstance(
 			String name,
 			String description,
@@ -19,11 +36,21 @@ public class UpdatedInstance extends Instance {
 			ImageSource imageSource,
 			Long flavorId,
 			Long id,
-			LocalDateTime createdAt) {
-		// updatedAt is set to null because it is set by the repository layer
-		super(name, description, alias, powerStatus, host, imageSource, flavorId, id, createdAt, null);
+			@NonNull LocalDateTime createdAt,
+			@NonNull LocalDateTime updatedAt) {
+		super(name, description, alias, powerStatus, host, imageSource, flavorId, id);
+		this.createdAt = createdAt;
+		this.updatedAt = updatedAt;
 	}
 
+	public static boolean isPersisted(UpdatedInstance instance) {
+		return instance.getCreatedAt() != null && instance.getUpdatedAt() != null;
+	}
+
+	/**
+	 * Use this method to update the instance with a new power status. This instance is not yet
+	 * persisted to the database.
+	 */
 	public static UpdatedInstance of(Instance instance, PowerStatus powerStatus) {
 		return new UpdatedInstance(
 				instance.getName(),
@@ -33,8 +60,7 @@ public class UpdatedInstance extends Instance {
 				instance.getHost(),
 				instance.getImageSource(),
 				instance.getFlavorId(),
-				instance.getId(),
-				instance.getCreatedAt());
+				instance.getId());
 	}
 
 	public static UpdatedInstance from(InstanceEntity entity) {
@@ -47,6 +73,7 @@ public class UpdatedInstance extends Instance {
 				entity.getImageSource(),
 				entity.getFlavorId(),
 				entity.getId(),
-				entity.getCreatedAt());
+				entity.getCreatedAt(),
+				entity.getUpdatedAt());
 	}
 }

--- a/src/main/java/com/okestro/resource/server/domain/vo/InstanceAlias.java
+++ b/src/main/java/com/okestro/resource/server/domain/vo/InstanceAlias.java
@@ -14,9 +14,9 @@ public class InstanceAlias {
 	private static final VerbalExpression REGEX =
 			VerbalExpression.regex()
 					.startOfLine()
-					.then("[a-zA-Z0-9]+") // key part
-					.then(SPLIT_REGEX) // underscore separator
-					.then("[0-9]{1,4}") // random number part
+					.add("[a-zA-Z0-9]+")
+					.then(SPLIT_REGEX)
+					.add("[0-9]{1,4}")
 					.endOfLine()
 					.build();
 	private final String value;

--- a/src/main/java/com/okestro/resource/server/event/ServerEventPublisher.java
+++ b/src/main/java/com/okestro/resource/server/event/ServerEventPublisher.java
@@ -1,5 +1,6 @@
 package com.okestro.resource.server.event;
 
+import com.okestro.resource.server.event.instance.InstanceEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -8,4 +9,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ServerEventPublisher {
 	private final ApplicationEventPublisher applicationEventPublisher;
+
+	public void publishEvent(
+			InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent.InstanceUpdateLogEvent
+					event) {
+		applicationEventPublisher.publishEvent(event);
+	}
 }

--- a/src/main/java/com/okestro/resource/server/event/instance/InstanceEvent.java
+++ b/src/main/java/com/okestro/resource/server/event/instance/InstanceEvent.java
@@ -25,5 +25,11 @@ public abstract class InstanceEvent {
 				this.log = json.getJson();
 			}
 		}
+
+		public static class InstanceUpdateLogEvent extends InstanceTransactionLogEvent {
+			public InstanceUpdateLogEvent(Long id, ServerActionJson json) {
+				super(id, json);
+			}
+		}
 	}
 }

--- a/src/main/java/com/okestro/resource/server/event/instance/InstanceTransactionEventListener.java
+++ b/src/main/java/com/okestro/resource/server/event/instance/InstanceTransactionEventListener.java
@@ -15,8 +15,8 @@ public class InstanceTransactionEventListener {
 	private final InstanceUpdateLogHandler instanceUpdateLogHandler;
 
 	@Async(value = DEFAULT_EXECUTOR)
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
-    public void afterCompletion(
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
+	public void afterCompletion(
 			InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent event) {
 		if (event
 				instanceof

--- a/src/main/java/com/okestro/resource/server/event/instance/InstanceTransactionEventListener.java
+++ b/src/main/java/com/okestro/resource/server/event/instance/InstanceTransactionEventListener.java
@@ -1,6 +1,10 @@
 package com.okestro.resource.server.event.instance;
 
+import static com.okestro.resource.config.AsyncConfig.DEFAULT_EXECUTOR;
+
+import com.okestro.resource.server.event.instance.handler.InstanceUpdateLogHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -8,7 +12,19 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 public class InstanceTransactionEventListener {
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
-	public void afterCompletion(
-			InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent event) {}
+	private final InstanceUpdateLogHandler instanceUpdateLogHandler;
+
+	@Async(value = DEFAULT_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)
+    public void afterCompletion(
+			InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent event) {
+		if (event
+				instanceof
+				InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent.InstanceUpdateLogEvent) {
+			instanceUpdateLogHandler.handle(
+					(InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent
+									.InstanceUpdateLogEvent)
+							event);
+		}
+	}
 }

--- a/src/main/java/com/okestro/resource/server/event/instance/handler/InstanceUpdateLogHandler.java
+++ b/src/main/java/com/okestro/resource/server/event/instance/handler/InstanceUpdateLogHandler.java
@@ -1,0 +1,28 @@
+package com.okestro.resource.server.event.instance.handler;
+
+import com.okestro.resource.server.domain.InstanceActiveLogEntity;
+import com.okestro.resource.server.domain.repository.InstanceActiveLogRepository;
+import com.okestro.resource.server.event.instance.InstanceEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class InstanceUpdateLogHandler {
+	private final InstanceActiveLogRepository instanceActiveLogRepository;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handle(
+			InstanceEvent.InstanceTransactionEvent.InstanceTransactionLogEvent.InstanceUpdateLogEvent
+					event) {
+		Long instanceId = event.getId();
+		String log = event.getLog();
+
+		InstanceActiveLogEntity logEntity =
+				InstanceActiveLogEntity.builder().instanceId(instanceId).log(log).build();
+
+		instanceActiveLogRepository.save(logEntity);
+	}
+}

--- a/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
+++ b/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
@@ -1,0 +1,179 @@
+package com.okestro.resource.server.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.okestro.resource.server.application.dto.UpdateInstancePowerUsecaseDto;
+import com.okestro.resource.server.application.service.power.*;
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.enums.SourceType;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import com.okestro.resource.server.event.ServerEventPublisher;
+import com.okestro.resource.server.support.json.ServerJsonConverter;
+import com.okestro.resource.support.web.converter.LocalDateJsonConverter;
+import com.okestro.resource.support.web.converter.LocalDateTimeJsonConverter;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.mockito.verification.VerificationMode;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class UpdateInstancePowerUseCaseTest {
+	static VerificationMode notCalled = times(0);
+
+	@Mock private ServerEventPublisher serverEventPublisher;
+	private final ServerJsonConverter serverJsonConverter =
+			new ServerJsonConverter(
+					Jackson2ObjectMapperBuilder.json()
+							.failOnUnknownProperties(false)
+							.serializationInclusion(JsonInclude.Include.NON_ABSENT)
+							.modules(
+									new JavaTimeModule()
+											.addSerializer(
+													LocalDateTime.class, new LocalDateTimeJsonConverter.Serializer())
+											.addDeserializer(
+													LocalDateTime.class, new LocalDateTimeJsonConverter.Deserializer())
+											.addSerializer(LocalDate.class, new LocalDateJsonConverter.Serializer())
+											.addDeserializer(LocalDate.class, new LocalDateJsonConverter.Deserializer()))
+							.featuresToEnable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+							.featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+							.build());
+	@Mock private InstanceRepository instanceRepository;
+	@Mock private InstancePowerActionManager instancePowerActionManager;
+
+	private UpdateInstancePowerUseCase updateInstancePowerUseCase;
+
+	@BeforeEach
+	void setUp() {
+		updateInstancePowerUseCase =
+				new UpdateInstancePowerUseCase(
+						serverEventPublisher,
+						serverJsonConverter,
+						instanceRepository,
+						instancePowerActionManager);
+	}
+
+	@Test
+	void update_instance_power_status_start() {
+		// given
+		Long instanceId = 1L;
+		InstancePowerStatusAction action = InstancePowerStatusAction.START;
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		InstanceEntity instanceEntity =
+				InstanceEntity.builder()
+						.id(instanceId)
+						.name("test-instance")
+						.description("This is a test instance")
+						.alias(InstanceAlias.create("test"))
+						.powerStatus(PowerStatus.SHUTDOWN)
+						.host(new InstanceHost("localhost"))
+						.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
+						.flavorId(1L)
+						.createdAt(createdDate)
+						.updatedAt(createdDate)
+						.build();
+		Instance instance = Instance.from(instanceEntity);
+		UpdatedInstance updatedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+
+		given(instanceRepository.findById(instanceId)).willReturn(Optional.of(instanceEntity));
+		given(instancePowerActionManager.execute(any(Instance.class), eq(action)))
+				.willReturn(updatedInstance);
+
+		// when
+		UpdateInstancePowerUsecaseDto.UpdateInstanceUseCaseOut result =
+				updateInstancePowerUseCase.execute(
+						UpdateInstancePowerUsecaseDto.UpdateInstancePowerUseCaseIn.builder()
+								.instanceId(instanceId)
+								.powerStatusAction(action)
+								.build());
+
+		// then
+		then(instanceRepository).should(times(1)).findById(instanceId);
+		then(instancePowerActionManager).should(times(1)).execute(any(Instance.class), eq(action));
+	}
+
+	@Test
+	void fail_to_update_instance_power_status_cause_not_found_instance() {
+		// given
+		Long instanceId = 1L;
+		InstancePowerStatusAction action = InstancePowerStatusAction.START;
+		given(instanceRepository.findById(instanceId)).willReturn(Optional.empty());
+
+		// when
+		assertThrows(
+				IllegalArgumentException.class,
+				() ->
+						updateInstancePowerUseCase.execute(
+								UpdateInstancePowerUsecaseDto.UpdateInstancePowerUseCaseIn.builder()
+										.instanceId(instanceId)
+										.powerStatusAction(action)
+										.build()));
+
+		// then
+		then(instanceRepository).should(times(1)).findById(instanceId);
+		then(instancePowerActionManager)
+				.should(notCalled)
+				.execute(any(Instance.class), any(InstancePowerStatusAction.class));
+	}
+
+	@Test
+	void fail_to_update_instance_power_status_cause_unsupported_action() {
+		// given
+		Long instanceId = 1L;
+		InstancePowerStatusAction action = InstancePowerStatusAction.START;
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		InstanceEntity instanceEntity =
+				InstanceEntity.builder()
+						.id(instanceId)
+						.name("test-instance")
+						.description("This is a test instance")
+						.alias(InstanceAlias.create("test"))
+						.powerStatus(PowerStatus.SHUTDOWN)
+						.host(new InstanceHost("localhost"))
+						.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
+						.flavorId(1L)
+						.createdAt(createdDate)
+						.updatedAt(createdDate)
+						.build();
+
+		given(instanceRepository.findById(instanceId)).willReturn(Optional.of(instanceEntity));
+		given(instancePowerActionManager.execute(any(Instance.class), eq(action)))
+				.willThrow(new IllegalArgumentException("Unsupported action: " + action));
+
+		// when
+		assertThrows(
+				IllegalArgumentException.class,
+				() ->
+						updateInstancePowerUseCase.execute(
+								UpdateInstancePowerUsecaseDto.UpdateInstancePowerUseCaseIn.builder()
+										.instanceId(instanceId)
+										.powerStatusAction(action)
+										.build()));
+
+		// then
+		then(instanceRepository).should(times(1)).findById(instanceId);
+		then(instancePowerActionManager).should(times(1)).execute(any(Instance.class), eq(action));
+	}
+}

--- a/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
+++ b/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
@@ -11,14 +11,11 @@ import com.okestro.resource.server.application.dto.UpdateInstancePowerUsecaseDto
 import com.okestro.resource.server.application.service.power.*;
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.InstanceEntityFixtures;
 import com.okestro.resource.server.domain.enums.PowerStatus;
-import com.okestro.resource.server.domain.enums.SourceType;
 import com.okestro.resource.server.domain.model.instance.Instance;
 import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import com.okestro.resource.server.domain.repository.InstanceRepository;
-import com.okestro.resource.server.domain.vo.ImageSource;
-import com.okestro.resource.server.domain.vo.InstanceAlias;
-import com.okestro.resource.server.domain.vo.InstanceHost;
 import com.okestro.resource.server.event.ServerEventPublisher;
 import com.okestro.resource.server.event.instance.InstanceEvent;
 import com.okestro.resource.server.support.json.ServerJsonConverter;
@@ -79,20 +76,8 @@ class UpdateInstancePowerUseCaseTest {
 		// given
 		Long instanceId = 1L;
 		InstancePowerStatusAction action = InstancePowerStatusAction.START;
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
 		InstanceEntity instanceEntity =
-				InstanceEntity.builder()
-						.id(instanceId)
-						.name("test-instance")
-						.description("This is a test instance")
-						.alias(InstanceAlias.create("test"))
-						.powerStatus(PowerStatus.SHUTDOWN)
-						.host(new InstanceHost("localhost"))
-						.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-						.flavorId(1L)
-						.createdAt(createdDate)
-						.updatedAt(createdDate)
-						.build();
+				InstanceEntityFixtures.giveMeOne().withPowerStatus(PowerStatus.SHUTDOWN).build();
 
 		InstanceEntity updatedInstanceEntity =
 				InstanceEntity.builder()
@@ -138,19 +123,7 @@ class UpdateInstancePowerUseCaseTest {
 		Long instanceId = 1L;
 		InstancePowerStatusAction action = InstancePowerStatusAction.START;
 		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
-		InstanceEntity instanceEntity =
-				InstanceEntity.builder()
-						.id(instanceId)
-						.name("test-instance")
-						.description("This is a test instance")
-						.alias(InstanceAlias.create("test"))
-						.powerStatus(PowerStatus.RUNNING)
-						.host(new InstanceHost("localhost"))
-						.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-						.flavorId(1L)
-						.createdAt(createdDate)
-						.updatedAt(createdDate)
-						.build();
+		InstanceEntity instanceEntity = InstanceEntityFixtures.giveMeOne().build();
 		Instance instance = Instance.from(instanceEntity);
 
 		given(instanceRepository.findById(instanceId)).willReturn(Optional.of(instanceEntity));
@@ -206,18 +179,7 @@ class UpdateInstancePowerUseCaseTest {
 		InstancePowerStatusAction action = InstancePowerStatusAction.START;
 		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
 		InstanceEntity instanceEntity =
-				InstanceEntity.builder()
-						.id(instanceId)
-						.name("test-instance")
-						.description("This is a test instance")
-						.alias(InstanceAlias.create("test"))
-						.powerStatus(PowerStatus.SHUTDOWN)
-						.host(new InstanceHost("localhost"))
-						.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-						.flavorId(1L)
-						.createdAt(createdDate)
-						.updatedAt(createdDate)
-						.build();
+				InstanceEntityFixtures.giveMeOne().withPowerStatus(PowerStatus.SHUTDOWN).build();
 
 		given(instanceRepository.findById(instanceId)).willReturn(Optional.of(instanceEntity));
 		given(instancePowerActionManager.execute(any(Instance.class), eq(action)))

--- a/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
+++ b/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
@@ -94,7 +94,8 @@ class UpdateInstancePowerUseCaseTest {
 						.updatedAt(createdDate)
 						.build();
 		Instance instance = Instance.from(instanceEntity);
-		UpdatedInstance updatedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
+		UpdatedInstance updatedInstance =
+				UpdatedInstance.of(instance, InstancePowerStatusActionSupporter.getPowerStatus(action));
 
 		given(instanceRepository.findById(instanceId)).willReturn(Optional.of(instanceEntity));
 		given(instancePowerActionManager.execute(any(Instance.class), eq(action)))

--- a/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
+++ b/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
@@ -93,9 +93,21 @@ class UpdateInstancePowerUseCaseTest {
 						.createdAt(createdDate)
 						.updatedAt(createdDate)
 						.build();
-		Instance instance = Instance.from(instanceEntity);
-		UpdatedInstance updatedInstance =
-				UpdatedInstance.of(instance, InstancePowerStatusActionSupporter.getPowerStatus(action));
+
+		InstanceEntity updatedInstanceEntity =
+				InstanceEntity.builder()
+						.id(instanceEntity.getId())
+						.name(instanceEntity.getName())
+						.description(instanceEntity.getDescription())
+						.alias(instanceEntity.getAlias())
+						.powerStatus(PowerStatus.RUNNING)
+						.host(instanceEntity.getHost())
+						.imageSource(instanceEntity.getImageSource())
+						.flavorId(instanceEntity.getFlavorId())
+						.createdAt(instanceEntity.getCreatedAt())
+						.updatedAt(LocalDateTime.now())
+						.build();
+		UpdatedInstance updatedInstance = UpdatedInstance.from(updatedInstanceEntity);
 
 		given(instanceRepository.findById(instanceId)).willReturn(Optional.of(instanceEntity));
 		given(instancePowerActionManager.execute(any(Instance.class), eq(action)))

--- a/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
+++ b/src/test/java/com/okestro/resource/server/application/UpdateInstancePowerUseCaseTest.java
@@ -2,7 +2,6 @@ package com.okestro.resource.server.application;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -95,7 +94,7 @@ class UpdateInstancePowerUseCaseTest {
 						.updatedAt(createdDate)
 						.build();
 		Instance instance = Instance.from(instanceEntity);
-		UpdatedInstance updatedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		UpdatedInstance updatedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
 
 		given(instanceRepository.findById(instanceId)).willReturn(Optional.of(instanceEntity));
 		given(instancePowerActionManager.execute(any(Instance.class), eq(action)))

--- a/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
@@ -1,6 +1,5 @@
 package com.okestro.resource.server.application.service.power;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
@@ -60,7 +59,7 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.SHUTDOWN);
 		InstancePowerStatusAction action = InstancePowerStatusAction.START;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
 		given(startInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -70,7 +69,7 @@ class InstancePowerActionManagerTest {
 		// then
 		then(startInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
 		then(shutdownInstancePowerActionService)
 				.should(never())
 				.doExecute(any(Instance.class), any(PowerStatus.class));
@@ -88,7 +87,7 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.RUNNING);
 		InstancePowerStatusAction action = InstancePowerStatusAction.SHUTDOWN;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
 		given(shutdownInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -101,7 +100,7 @@ class InstancePowerActionManagerTest {
 				.doExecute(any(Instance.class), any(PowerStatus.class));
 		then(shutdownInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
 		then(pauseInstancePowerActionService)
 				.should(never())
 				.doExecute(any(Instance.class), any(PowerStatus.class));
@@ -116,7 +115,7 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.RUNNING);
 		InstancePowerStatusAction action = InstancePowerStatusAction.PAUSE;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
 		given(pauseInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -132,7 +131,7 @@ class InstancePowerActionManagerTest {
 				.doExecute(any(Instance.class), any(PowerStatus.class));
 		then(pauseInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
 		then(rebootInstancePowerActionService)
 				.should(never())
 				.doExecute(any(Instance.class), any(PowerStatus.class));
@@ -144,7 +143,7 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.RUNNING);
 		InstancePowerStatusAction action = InstancePowerStatusAction.REBOOT;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
 		given(rebootInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -163,7 +162,7 @@ class InstancePowerActionManagerTest {
 				.doExecute(any(Instance.class), any(PowerStatus.class));
 		then(rebootInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
 	}
 
 	private Instance createTestInstance(PowerStatus powerStatus) {

--- a/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
@@ -6,14 +6,10 @@ import static org.mockito.Mockito.*;
 
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.InstanceEntityFixtures;
 import com.okestro.resource.server.domain.enums.PowerStatus;
-import com.okestro.resource.server.domain.enums.SourceType;
 import com.okestro.resource.server.domain.model.instance.Instance;
 import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
-import com.okestro.resource.server.domain.vo.ImageSource;
-import com.okestro.resource.server.domain.vo.InstanceAlias;
-import com.okestro.resource.server.domain.vo.InstanceHost;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -174,20 +170,8 @@ class InstancePowerActionManagerTest {
 	}
 
 	private Instance createTestInstance(PowerStatus powerStatus) {
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
 		InstanceEntity instanceEntity =
-				InstanceEntity.builder()
-						.id(1L)
-						.name("test-instance")
-						.description("This is a test instance")
-						.alias(InstanceAlias.create("test"))
-						.powerStatus(powerStatus)
-						.host(new InstanceHost("localhost"))
-						.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-						.flavorId(1L)
-						.createdAt(createdDate)
-						.updatedAt(createdDate)
-						.build();
+				InstanceEntityFixtures.giveMeOne().withPowerStatus(powerStatus).build();
 		return Instance.from(instanceEntity);
 	}
 }

--- a/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
@@ -59,7 +59,8 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.SHUTDOWN);
 		InstancePowerStatusAction action = InstancePowerStatusAction.START;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
+		Instance expectedInstance =
+				UpdatedInstance.of(instance, InstancePowerStatusActionSupporter.getPowerStatus(action));
 		given(startInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -69,7 +70,8 @@ class InstancePowerActionManagerTest {
 		// then
 		then(startInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
+				.doExecute(
+						any(Instance.class), eq(InstancePowerStatusActionSupporter.getPowerStatus(action)));
 		then(shutdownInstancePowerActionService)
 				.should(never())
 				.doExecute(any(Instance.class), any(PowerStatus.class));
@@ -87,7 +89,8 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.RUNNING);
 		InstancePowerStatusAction action = InstancePowerStatusAction.SHUTDOWN;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
+		Instance expectedInstance =
+				UpdatedInstance.of(instance, InstancePowerStatusActionSupporter.getPowerStatus(action));
 		given(shutdownInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -100,7 +103,8 @@ class InstancePowerActionManagerTest {
 				.doExecute(any(Instance.class), any(PowerStatus.class));
 		then(shutdownInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
+				.doExecute(
+						any(Instance.class), eq(InstancePowerStatusActionSupporter.getPowerStatus(action)));
 		then(pauseInstancePowerActionService)
 				.should(never())
 				.doExecute(any(Instance.class), any(PowerStatus.class));
@@ -115,7 +119,8 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.RUNNING);
 		InstancePowerStatusAction action = InstancePowerStatusAction.PAUSE;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
+		Instance expectedInstance =
+				UpdatedInstance.of(instance, InstancePowerStatusActionSupporter.getPowerStatus(action));
 		given(pauseInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -131,7 +136,8 @@ class InstancePowerActionManagerTest {
 				.doExecute(any(Instance.class), any(PowerStatus.class));
 		then(pauseInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
+				.doExecute(
+						any(Instance.class), eq(InstancePowerStatusActionSupporter.getPowerStatus(action)));
 		then(rebootInstancePowerActionService)
 				.should(never())
 				.doExecute(any(Instance.class), any(PowerStatus.class));
@@ -143,7 +149,8 @@ class InstancePowerActionManagerTest {
 		Instance instance = createTestInstance(PowerStatus.RUNNING);
 		InstancePowerStatusAction action = InstancePowerStatusAction.REBOOT;
 
-		Instance expectedInstance = UpdatedInstance.of(instance, action.expectedPowerStatus());
+		Instance expectedInstance =
+				UpdatedInstance.of(instance, InstancePowerStatusActionSupporter.getPowerStatus(action));
 		given(rebootInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
 				.willReturn(expectedInstance);
 
@@ -162,7 +169,8 @@ class InstancePowerActionManagerTest {
 				.doExecute(any(Instance.class), any(PowerStatus.class));
 		then(rebootInstancePowerActionService)
 				.should(times(1))
-				.doExecute(any(Instance.class), eq(action.expectedPowerStatus()));
+				.doExecute(
+						any(Instance.class), eq(InstancePowerStatusActionSupporter.getPowerStatus(action)));
 	}
 
 	private Instance createTestInstance(PowerStatus powerStatus) {

--- a/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/InstancePowerActionManagerTest.java
@@ -1,0 +1,186 @@
+package com.okestro.resource.server.application.service.power;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.enums.SourceType;
+import com.okestro.resource.server.domain.model.instance.Instance;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class InstancePowerActionManagerTest {
+	@Mock private StartInstancePowerActionService startInstancePowerActionService;
+	@Mock private ShutdownInstancePowerActionService shutdownInstancePowerActionService;
+	@Mock private PauseInstancePowerActionService pauseInstancePowerActionService;
+	@Mock private RebootInstancePowerActionService rebootInstancePowerActionService;
+
+	private InstancePowerActionManager instancePowerActionManager;
+
+	@BeforeEach
+	void setUp() {
+		given(startInstancePowerActionService.supportAction())
+				.willReturn(InstancePowerStatusAction.START);
+		given(shutdownInstancePowerActionService.supportAction())
+				.willReturn(InstancePowerStatusAction.SHUTDOWN);
+		given(pauseInstancePowerActionService.supportAction())
+				.willReturn(InstancePowerStatusAction.PAUSE);
+		given(rebootInstancePowerActionService.supportAction())
+				.willReturn(InstancePowerStatusAction.REBOOT);
+
+		instancePowerActionManager =
+				new InstancePowerActionManager(
+						List.of(
+								startInstancePowerActionService,
+								shutdownInstancePowerActionService,
+								pauseInstancePowerActionService,
+								rebootInstancePowerActionService));
+	}
+
+	@Test
+	void should_select_start_service_when_action_is_start() {
+		// given
+		Instance instance = createTestInstance(PowerStatus.SHUTDOWN);
+		InstancePowerStatusAction action = InstancePowerStatusAction.START;
+
+		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		given(startInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
+				.willReturn(expectedInstance);
+
+		// when
+		Instance result = instancePowerActionManager.execute(instance, action);
+
+		// then
+		then(startInstancePowerActionService)
+				.should(times(1))
+				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+		then(shutdownInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(pauseInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(rebootInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+	}
+
+	@Test
+	void should_select_shutdown_service_when_action_is_shutdown() {
+		// given
+		Instance instance = createTestInstance(PowerStatus.RUNNING);
+		InstancePowerStatusAction action = InstancePowerStatusAction.SHUTDOWN;
+
+		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		given(shutdownInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
+				.willReturn(expectedInstance);
+
+		// when
+		Instance result = instancePowerActionManager.execute(instance, action);
+
+		// then
+		then(startInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(shutdownInstancePowerActionService)
+				.should(times(1))
+				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+		then(pauseInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(rebootInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+	}
+
+	@Test
+	void should_select_pause_service_when_action_is_pause() {
+		// given
+		Instance instance = createTestInstance(PowerStatus.RUNNING);
+		InstancePowerStatusAction action = InstancePowerStatusAction.PAUSE;
+
+		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		given(pauseInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
+				.willReturn(expectedInstance);
+
+		// when
+		Instance result = instancePowerActionManager.execute(instance, action);
+
+		// then
+		then(startInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(shutdownInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(pauseInstancePowerActionService)
+				.should(times(1))
+				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+		then(rebootInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+	}
+
+	@Test
+	void should_select_reboot_service_when_action_is_reboot() {
+		// given
+		Instance instance = createTestInstance(PowerStatus.RUNNING);
+		InstancePowerStatusAction action = InstancePowerStatusAction.REBOOT;
+
+		Instance expectedInstance = UpdatedInstance.of(instance, action.wantPowerStatus());
+		given(rebootInstancePowerActionService.doExecute(any(Instance.class), any(PowerStatus.class)))
+				.willReturn(expectedInstance);
+
+		// when
+		Instance result = instancePowerActionManager.execute(instance, action);
+
+		// then
+		then(startInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(shutdownInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(pauseInstancePowerActionService)
+				.should(never())
+				.doExecute(any(Instance.class), any(PowerStatus.class));
+		then(rebootInstancePowerActionService)
+				.should(times(1))
+				.doExecute(any(Instance.class), eq(action.wantPowerStatus()));
+	}
+
+	private Instance createTestInstance(PowerStatus powerStatus) {
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		InstanceEntity instanceEntity =
+				InstanceEntity.builder()
+						.id(1L)
+						.name("test-instance")
+						.description("This is a test instance")
+						.alias(InstanceAlias.create("test"))
+						.powerStatus(powerStatus)
+						.host(new InstanceHost("localhost"))
+						.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
+						.flavorId(1L)
+						.createdAt(createdDate)
+						.updatedAt(createdDate)
+						.build();
+		return Instance.from(instanceEntity);
+	}
+}

--- a/src/test/java/com/okestro/resource/server/application/service/power/PauseInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/PauseInstancePowerActionServiceTest.java
@@ -7,14 +7,10 @@ import static org.mockito.Mockito.times;
 
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.InstanceEntityFixtures;
 import com.okestro.resource.server.domain.enums.PowerStatus;
-import com.okestro.resource.server.domain.enums.SourceType;
 import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import com.okestro.resource.server.domain.repository.InstanceRepository;
-import com.okestro.resource.server.domain.vo.ImageSource;
-import com.okestro.resource.server.domain.vo.InstanceAlias;
-import com.okestro.resource.server.domain.vo.InstanceHost;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,22 +47,8 @@ class PauseInstancePowerActionServiceTest {
 		// given
 		Long instanceId = 1L;
 		PowerStatus expected = PowerStatus.PAUSED;
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
 		given(instanceRepository.findById(instanceId))
-				.willReturn(
-						Optional.of(
-								InstanceEntity.builder()
-										.id(instanceId)
-										.name("Test Instance")
-										.description("This is a test instance")
-										.alias(InstanceAlias.create("test"))
-										.powerStatus(PowerStatus.RUNNING)
-										.host(new InstanceHost("localhost"))
-										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-										.flavorId(1L)
-										.createdAt(createdDate)
-										.updatedAt(createdDate)
-										.build()));
+				.willReturn(Optional.of(InstanceEntityFixtures.giveMeOne().withId(instanceId).build()));
 
 		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
 				.willAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/okestro/resource/server/application/service/power/PauseInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/PauseInstancePowerActionServiceTest.java
@@ -1,0 +1,83 @@
+package com.okestro.resource.server.application.service.power;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.enums.SourceType;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class PauseInstancePowerActionServiceTest {
+	@Mock private InstanceRepository instanceRepository;
+
+	private PauseInstancePowerActionService pauseInstancePowerActionService;
+
+	@BeforeEach
+	void setUp() {
+		pauseInstancePowerActionService = new PauseInstancePowerActionService(instanceRepository);
+	}
+
+	@Test
+	void support_action() {
+		// when
+		InstancePowerStatusAction action = pauseInstancePowerActionService.supportAction();
+
+		// then
+		assertEquals(InstancePowerStatusAction.PAUSE, action);
+	}
+
+	@Test
+	void update_instance() {
+		// given
+		Long instanceId = 1L;
+		PowerStatus expected = PowerStatus.PAUSED;
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		given(instanceRepository.findById(instanceId))
+				.willReturn(
+						Optional.of(
+								InstanceEntity.builder()
+										.id(instanceId)
+										.name("Test Instance")
+										.description("This is a test instance")
+										.alias(InstanceAlias.create("test"))
+										.powerStatus(PowerStatus.RUNNING)
+										.host(new InstanceHost("localhost"))
+										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
+										.flavorId(1L)
+										.createdAt(createdDate)
+										.updatedAt(createdDate)
+										.build()));
+
+		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		UpdatedInstance updatedInstance =
+				pauseInstancePowerActionService.updateInstance(instanceId, expected);
+
+		// then
+		assertEquals(expected, updatedInstance.getPowerStatus());
+		then(instanceRepository).should(times(1)).findById(instanceId);
+		then(instanceRepository).should(times(1)).save(Mockito.any(InstanceEntity.class));
+	}
+}

--- a/src/test/java/com/okestro/resource/server/application/service/power/RebootInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/RebootInstancePowerActionServiceTest.java
@@ -7,13 +7,10 @@ import static org.mockito.Mockito.times;
 
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.InstanceEntityFixtures;
 import com.okestro.resource.server.domain.enums.PowerStatus;
-import com.okestro.resource.server.domain.enums.SourceType;
 import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import com.okestro.resource.server.domain.repository.InstanceRepository;
-import com.okestro.resource.server.domain.vo.ImageSource;
-import com.okestro.resource.server.domain.vo.InstanceAlias;
-import com.okestro.resource.server.domain.vo.InstanceHost;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,20 +50,7 @@ class RebootInstancePowerActionServiceTest {
 		PowerStatus expected = PowerStatus.RUNNING;
 		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
 		given(instanceRepository.findById(instanceId))
-				.willReturn(
-						Optional.of(
-								InstanceEntity.builder()
-										.id(instanceId)
-										.name("Test Instance")
-										.description("This is a test instance")
-										.alias(InstanceAlias.create("test"))
-										.powerStatus(PowerStatus.RUNNING)
-										.host(new InstanceHost("localhost"))
-										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-										.flavorId(1L)
-										.createdAt(createdDate)
-										.updatedAt(createdDate)
-										.build()));
+				.willReturn(Optional.of(InstanceEntityFixtures.giveMeOne().withId(instanceId).build()));
 
 		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
 				.willAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/okestro/resource/server/application/service/power/RebootInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/RebootInstancePowerActionServiceTest.java
@@ -1,0 +1,83 @@
+package com.okestro.resource.server.application.service.power;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.enums.SourceType;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class RebootInstancePowerActionServiceTest {
+	@Mock private InstanceRepository instanceRepository;
+
+	private RebootInstancePowerActionService rebootInstancePowerActionService;
+
+	@BeforeEach
+	void setUp() {
+		rebootInstancePowerActionService = new RebootInstancePowerActionService(instanceRepository);
+	}
+
+	@Test
+	void support_action() {
+		// when
+		InstancePowerStatusAction action = rebootInstancePowerActionService.supportAction();
+
+		// then
+		assertEquals(InstancePowerStatusAction.REBOOT, action);
+	}
+
+	@Test
+	void update_instance() {
+		// given
+		Long instanceId = 1L;
+		PowerStatus expected = PowerStatus.RUNNING;
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		given(instanceRepository.findById(instanceId))
+				.willReturn(
+						Optional.of(
+								InstanceEntity.builder()
+										.id(instanceId)
+										.name("Test Instance")
+										.description("This is a test instance")
+										.alias(InstanceAlias.create("test"))
+										.powerStatus(PowerStatus.RUNNING)
+										.host(new InstanceHost("localhost"))
+										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
+										.flavorId(1L)
+										.createdAt(createdDate)
+										.updatedAt(createdDate)
+										.build()));
+
+		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		UpdatedInstance updatedInstance =
+				rebootInstancePowerActionService.updateInstance(instanceId, expected);
+
+		// then
+		assertEquals(expected, updatedInstance.getPowerStatus());
+		then(instanceRepository).should(times(1)).findById(instanceId);
+		then(instanceRepository).should(times(2)).save(Mockito.any(InstanceEntity.class));
+	}
+}

--- a/src/test/java/com/okestro/resource/server/application/service/power/ShutdownInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/ShutdownInstancePowerActionServiceTest.java
@@ -1,0 +1,83 @@
+package com.okestro.resource.server.application.service.power;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.enums.SourceType;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class ShutdownInstancePowerActionServiceTest {
+	@Mock private InstanceRepository instanceRepository;
+
+	private ShutdownInstancePowerActionService shutdownInstancePowerActionService;
+
+	@BeforeEach
+	void setUp() {
+		shutdownInstancePowerActionService = new ShutdownInstancePowerActionService(instanceRepository);
+	}
+
+	@Test
+	void support_action() {
+		// when
+		InstancePowerStatusAction action = shutdownInstancePowerActionService.supportAction();
+
+		// then
+		assertEquals(InstancePowerStatusAction.SHUTDOWN, action);
+	}
+
+	@Test
+	void update_instance() {
+		// given
+		Long instanceId = 1L;
+		PowerStatus expected = PowerStatus.SHUTDOWN;
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		given(instanceRepository.findById(instanceId))
+				.willReturn(
+						Optional.of(
+								InstanceEntity.builder()
+										.id(instanceId)
+										.name("Test Instance")
+										.description("This is a test instance")
+										.alias(InstanceAlias.create("test"))
+										.powerStatus(PowerStatus.RUNNING)
+										.host(new InstanceHost("localhost"))
+										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
+										.flavorId(1L)
+										.createdAt(createdDate)
+										.updatedAt(createdDate)
+										.build()));
+
+		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		UpdatedInstance updatedInstance =
+				shutdownInstancePowerActionService.updateInstance(instanceId, expected);
+
+		// then
+		assertEquals(expected, updatedInstance.getPowerStatus());
+		then(instanceRepository).should(times(1)).findById(instanceId);
+		then(instanceRepository).should(times(1)).save(Mockito.any(InstanceEntity.class));
+	}
+}

--- a/src/test/java/com/okestro/resource/server/application/service/power/ShutdownInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/ShutdownInstancePowerActionServiceTest.java
@@ -7,14 +7,10 @@ import static org.mockito.Mockito.times;
 
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.InstanceEntityFixtures;
 import com.okestro.resource.server.domain.enums.PowerStatus;
-import com.okestro.resource.server.domain.enums.SourceType;
 import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import com.okestro.resource.server.domain.repository.InstanceRepository;
-import com.okestro.resource.server.domain.vo.ImageSource;
-import com.okestro.resource.server.domain.vo.InstanceAlias;
-import com.okestro.resource.server.domain.vo.InstanceHost;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,22 +47,8 @@ class ShutdownInstancePowerActionServiceTest {
 		// given
 		Long instanceId = 1L;
 		PowerStatus expected = PowerStatus.SHUTDOWN;
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
 		given(instanceRepository.findById(instanceId))
-				.willReturn(
-						Optional.of(
-								InstanceEntity.builder()
-										.id(instanceId)
-										.name("Test Instance")
-										.description("This is a test instance")
-										.alias(InstanceAlias.create("test"))
-										.powerStatus(PowerStatus.RUNNING)
-										.host(new InstanceHost("localhost"))
-										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-										.flavorId(1L)
-										.createdAt(createdDate)
-										.updatedAt(createdDate)
-										.build()));
+				.willReturn(Optional.of(InstanceEntityFixtures.giveMeOne().withId(instanceId).build()));
 
 		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
 				.willAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/okestro/resource/server/application/service/power/StartInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/StartInstancePowerActionServiceTest.java
@@ -7,14 +7,10 @@ import static org.mockito.Mockito.times;
 
 import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
 import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.InstanceEntityFixtures;
 import com.okestro.resource.server.domain.enums.PowerStatus;
-import com.okestro.resource.server.domain.enums.SourceType;
 import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
 import com.okestro.resource.server.domain.repository.InstanceRepository;
-import com.okestro.resource.server.domain.vo.ImageSource;
-import com.okestro.resource.server.domain.vo.InstanceAlias;
-import com.okestro.resource.server.domain.vo.InstanceHost;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,22 +47,8 @@ class StartInstancePowerActionServiceTest {
 		// given
 		Long instanceId = 1L;
 		PowerStatus expected = PowerStatus.RUNNING;
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
 		given(instanceRepository.findById(instanceId))
-				.willReturn(
-						Optional.of(
-								InstanceEntity.builder()
-										.id(instanceId)
-										.name("Test Instance")
-										.description("This is a test instance")
-										.alias(InstanceAlias.create("test"))
-										.powerStatus(PowerStatus.SHUTDOWN)
-										.host(new InstanceHost("localhost"))
-										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
-										.flavorId(1L)
-										.createdAt(createdDate)
-										.updatedAt(createdDate)
-										.build()));
+				.willReturn(Optional.of(InstanceEntityFixtures.giveMeOne().withId(instanceId).build()));
 
 		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
 				.willAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/okestro/resource/server/application/service/power/StartInstancePowerActionServiceTest.java
+++ b/src/test/java/com/okestro/resource/server/application/service/power/StartInstancePowerActionServiceTest.java
@@ -1,0 +1,83 @@
+package com.okestro.resource.server.application.service.power;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.okestro.resource.server.controller.request.InstancePowerStatusAction;
+import com.okestro.resource.server.domain.InstanceEntity;
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.enums.SourceType;
+import com.okestro.resource.server.domain.model.instance.UpdatedInstance;
+import com.okestro.resource.server.domain.repository.InstanceRepository;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class StartInstancePowerActionServiceTest {
+	@Mock private InstanceRepository instanceRepository;
+
+	private StartInstancePowerActionService startInstancePowerActionService;
+
+	@BeforeEach
+	void setUp() {
+		startInstancePowerActionService = new StartInstancePowerActionService(instanceRepository);
+	}
+
+	@Test
+	void support_action() {
+		// when
+		InstancePowerStatusAction action = startInstancePowerActionService.supportAction();
+
+		// then
+		assertEquals(InstancePowerStatusAction.START, action);
+	}
+
+	@Test
+	void update_instance() {
+		// given
+		Long instanceId = 1L;
+		PowerStatus expected = PowerStatus.RUNNING;
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		given(instanceRepository.findById(instanceId))
+				.willReturn(
+						Optional.of(
+								InstanceEntity.builder()
+										.id(instanceId)
+										.name("Test Instance")
+										.description("This is a test instance")
+										.alias(InstanceAlias.create("test"))
+										.powerStatus(PowerStatus.SHUTDOWN)
+										.host(new InstanceHost("localhost"))
+										.imageSource(ImageSource.create(SourceType.IMAGE, 1L))
+										.flavorId(1L)
+										.createdAt(createdDate)
+										.updatedAt(createdDate)
+										.build()));
+
+		given(instanceRepository.save(Mockito.any(InstanceEntity.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		UpdatedInstance updatedInstance =
+				startInstancePowerActionService.updateInstance(instanceId, expected);
+
+		// then
+		assertEquals(expected, updatedInstance.getPowerStatus());
+		then(instanceRepository).should(times(1)).findById(instanceId);
+		then(instanceRepository).should(times(1)).save(Mockito.any(InstanceEntity.class));
+	}
+}

--- a/src/test/java/com/okestro/resource/server/domain/model/instance/InstanceTest.java
+++ b/src/test/java/com/okestro/resource/server/domain/model/instance/InstanceTest.java
@@ -3,28 +3,13 @@ package com.okestro.resource.server.domain.model.instance;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.okestro.resource.server.domain.enums.PowerStatus;
-import com.okestro.resource.server.domain.enums.SourceType;
-import com.okestro.resource.server.domain.vo.ImageSource;
-import com.okestro.resource.server.domain.vo.InstanceAlias;
-import com.okestro.resource.server.domain.vo.InstanceHost;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 class InstanceTest {
 
 	@Test
 	void start_instance() {
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
-		Instance instance =
-				new Instance(
-						"Test Instance",
-						"This is a test instance",
-						InstanceAlias.create("test"),
-						PowerStatus.SHUTDOWN,
-						new InstanceHost("localhost"),
-						ImageSource.create(SourceType.IMAGE, 1L),
-						1L,
-						1L);
+		Instance instance = InstanceFixtures.giveMeOne().build();
 
 		UpdatedInstance updatedInstance = instance.start();
 
@@ -34,17 +19,7 @@ class InstanceTest {
 
 	@Test
 	void stop_instance() {
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
-		Instance instance =
-				new Instance(
-						"Test Instance",
-						"This is a test instance",
-						InstanceAlias.create("test"),
-						PowerStatus.RUNNING,
-						new InstanceHost("localhost"),
-						ImageSource.create(SourceType.IMAGE, 1L),
-						1L,
-						1L);
+		Instance instance = InstanceFixtures.giveMeOne().build();
 
 		UpdatedInstance updatedInstance = instance.shutdown();
 
@@ -54,17 +29,7 @@ class InstanceTest {
 
 	@Test
 	void pause_instance() {
-		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
-		Instance instance =
-				new Instance(
-						"Test Instance",
-						"This is a test instance",
-						InstanceAlias.create("test"),
-						PowerStatus.RUNNING,
-						new InstanceHost("localhost"),
-						ImageSource.create(SourceType.IMAGE, 1L),
-						1L,
-						1L);
+		Instance instance = InstanceFixtures.giveMeOne().build();
 
 		UpdatedInstance updatedInstance = instance.pause();
 
@@ -74,16 +39,7 @@ class InstanceTest {
 
 	@Test
 	void shutdown_instance() {
-		Instance instance =
-				new Instance(
-						"Test Instance",
-						"This is a test instance",
-						InstanceAlias.create("test"),
-						PowerStatus.RUNNING,
-						new InstanceHost("localhost"),
-						ImageSource.create(SourceType.IMAGE, 1L),
-						1L,
-						1L);
+		Instance instance = InstanceFixtures.giveMeOne().build();
 
 		UpdatedInstance updatedInstance = instance.shutdown();
 

--- a/src/test/java/com/okestro/resource/server/domain/model/instance/InstanceTest.java
+++ b/src/test/java/com/okestro/resource/server/domain/model/instance/InstanceTest.java
@@ -24,15 +24,12 @@ class InstanceTest {
 						new InstanceHost("localhost"),
 						ImageSource.create(SourceType.IMAGE, 1L),
 						1L,
-						1L,
-						createdDate,
-						createdDate);
+						1L);
 
 		UpdatedInstance updatedInstance = instance.start();
 
 		assertNotNull(updatedInstance);
 		assertSame(PowerStatus.RUNNING, updatedInstance.getPowerStatus());
-		assertNull(updatedInstance.getUpdatedAt());
 	}
 
 	@Test
@@ -47,15 +44,12 @@ class InstanceTest {
 						new InstanceHost("localhost"),
 						ImageSource.create(SourceType.IMAGE, 1L),
 						1L,
-						1L,
-						createdDate,
-						createdDate);
+						1L);
 
 		UpdatedInstance updatedInstance = instance.shutdown();
 
 		assertNotNull(updatedInstance);
 		assertSame(PowerStatus.SHUTDOWN, updatedInstance.getPowerStatus());
-		assertNull(updatedInstance.getUpdatedAt());
 	}
 
 	@Test
@@ -70,15 +64,12 @@ class InstanceTest {
 						new InstanceHost("localhost"),
 						ImageSource.create(SourceType.IMAGE, 1L),
 						1L,
-						1L,
-						createdDate,
-						createdDate);
+						1L);
 
 		UpdatedInstance updatedInstance = instance.pause();
 
 		assertNotNull(updatedInstance);
 		assertSame(PowerStatus.PAUSED, updatedInstance.getPowerStatus());
-		assertNull(updatedInstance.getUpdatedAt());
 	}
 
 	@Test
@@ -92,14 +83,11 @@ class InstanceTest {
 						new InstanceHost("localhost"),
 						ImageSource.create(SourceType.IMAGE, 1L),
 						1L,
-						1L,
-						LocalDateTime.now().minusMinutes(10),
-						LocalDateTime.now().minusMinutes(10));
+						1L);
 
 		UpdatedInstance updatedInstance = instance.shutdown();
 
 		assertNotNull(updatedInstance);
 		assertSame(PowerStatus.SHUTDOWN, updatedInstance.getPowerStatus());
-		assertNull(updatedInstance.getUpdatedAt());
 	}
 }

--- a/src/test/java/com/okestro/resource/server/domain/model/instance/InstanceTest.java
+++ b/src/test/java/com/okestro/resource/server/domain/model/instance/InstanceTest.java
@@ -1,0 +1,105 @@
+package com.okestro.resource.server.domain.model.instance;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.okestro.resource.server.domain.enums.PowerStatus;
+import com.okestro.resource.server.domain.enums.SourceType;
+import com.okestro.resource.server.domain.vo.ImageSource;
+import com.okestro.resource.server.domain.vo.InstanceAlias;
+import com.okestro.resource.server.domain.vo.InstanceHost;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class InstanceTest {
+
+	@Test
+	void start_instance() {
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		Instance instance =
+				new Instance(
+						"Test Instance",
+						"This is a test instance",
+						InstanceAlias.create("test"),
+						PowerStatus.SHUTDOWN,
+						new InstanceHost("localhost"),
+						ImageSource.create(SourceType.IMAGE, 1L),
+						1L,
+						1L,
+						createdDate,
+						createdDate);
+
+		UpdatedInstance updatedInstance = instance.start();
+
+		assertNotNull(updatedInstance);
+		assertSame(PowerStatus.RUNNING, updatedInstance.getPowerStatus());
+		assertNull(updatedInstance.getUpdatedAt());
+	}
+
+	@Test
+	void stop_instance() {
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		Instance instance =
+				new Instance(
+						"Test Instance",
+						"This is a test instance",
+						InstanceAlias.create("test"),
+						PowerStatus.RUNNING,
+						new InstanceHost("localhost"),
+						ImageSource.create(SourceType.IMAGE, 1L),
+						1L,
+						1L,
+						createdDate,
+						createdDate);
+
+		UpdatedInstance updatedInstance = instance.shutdown();
+
+		assertNotNull(updatedInstance);
+		assertSame(PowerStatus.SHUTDOWN, updatedInstance.getPowerStatus());
+		assertNull(updatedInstance.getUpdatedAt());
+	}
+
+	@Test
+	void pause_instance() {
+		LocalDateTime createdDate = LocalDateTime.now().minusMinutes(10);
+		Instance instance =
+				new Instance(
+						"Test Instance",
+						"This is a test instance",
+						InstanceAlias.create("test"),
+						PowerStatus.RUNNING,
+						new InstanceHost("localhost"),
+						ImageSource.create(SourceType.IMAGE, 1L),
+						1L,
+						1L,
+						createdDate,
+						createdDate);
+
+		UpdatedInstance updatedInstance = instance.pause();
+
+		assertNotNull(updatedInstance);
+		assertSame(PowerStatus.PAUSED, updatedInstance.getPowerStatus());
+		assertNull(updatedInstance.getUpdatedAt());
+	}
+
+	@Test
+	void shutdown_instance() {
+		Instance instance =
+				new Instance(
+						"Test Instance",
+						"This is a test instance",
+						InstanceAlias.create("test"),
+						PowerStatus.RUNNING,
+						new InstanceHost("localhost"),
+						ImageSource.create(SourceType.IMAGE, 1L),
+						1L,
+						1L,
+						LocalDateTime.now().minusMinutes(10),
+						LocalDateTime.now().minusMinutes(10));
+
+		UpdatedInstance updatedInstance = instance.shutdown();
+
+		assertNotNull(updatedInstance);
+		assertSame(PowerStatus.SHUTDOWN, updatedInstance.getPowerStatus());
+		assertNull(updatedInstance.getUpdatedAt());
+	}
+}


### PR DESCRIPTION
# API 스펙
```json
// 요청
{
  "instanceId": 1024,
  "powerStatusAction": 1
}

// 응답 200
{
    "data": {
        "id": 1024,
        "name": "test-instance",
        "description": "enim ad sint",
        "alias": "instance_1855",
        "powerStatus": "SHUTDOWN",
        "host": "192.168.1.1"
    },
    "message": "성공",
    "code": "success"
}
```

# 실행 결과
## 200
![스크린샷 2025-05-28 오후 5 39 55](https://github.com/user-attachments/assets/b0d43939-195f-4455-816a-410e9bdd4900)

## 304
![스크린샷 2025-05-28 오후 5 40 17](https://github.com/user-attachments/assets/6986bff4-a182-4710-89cf-5b6ce1b369ed)

# API 로직 다이어그램
```mermaid
sequenceDiagram
    participant Client as Client
    participant Controller as ServerController
    participant UseCase as UpdateInstancePowerUseCase
    participant Repo as InstanceRepository
    participant Manager as InstancePowerActionManager
    participant Publisher as ServerEventPublisher
    participant Listener as InstanceTransactionEventListener
    participant Handler as InstanceUpdateLogHandler

    Client->>Controller: updateInstancePower(request)
    Controller->>UseCase: execute(useCaseIn)
    UseCase->>Repo: findById(instanceId)
    Repo-->>UseCase: InstanceEntity
    UseCase->>Manager: execute(instance, action)
    alt 상태 변경 발생
        Manager-->>UseCase: UpdatedInstance
        UseCase->>Publisher: publishEvent(InstanceUpdateLogEvent)
        Note right of Publisher: 트랜잭션 완료 이후 전달됨
        Publisher-->>Listener: InstanceUpdateLogEvent
        Listener->>Handler: handle(InstanceUpdateLogEvent)
        UseCase-->>Controller: 200 OK (변경됨)
    else 상태 동일
        Manager-->>UseCase: 동일 상태
        UseCase-->>Controller: 304 Not Modified (변경 없음)
    end
    Controller-->>Client: ApiResponse
```